### PR TITLE
Removed Fixnum and Bignum

### DIFF
--- a/lib/necromancer/conversion_target.rb
+++ b/lib/necromancer/conversion_target.rb
@@ -73,7 +73,7 @@ module Necromancer
     def detect(object, symbol_as_object = true)
       case object
       when TrueClass, FalseClass then :boolean
-      when Fixnum, Bignum then :integer
+      # when Fixnum, Bignum then :integer # ruby 2.4 deprecation
       else
         if object.is_a?(Symbol) && symbol_as_object
           object


### PR DESCRIPTION
Prints deprecation warnings about Fixnum and Bignum, in ruby 2.4 these types are unified to integer.